### PR TITLE
Adds `iterator_diff_` and `iterator_intersect_` functions

### DIFF
--- a/src/Iterator/DiffIterator.php
+++ b/src/Iterator/DiffIterator.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace DoekeNorg\IteratorFunctions\Iterator;
+
+/**
+ * Iterator that computes the difference between multiple iterators.
+ */
+class DiffIterator extends \FilterIterator
+{
+    /**
+     * Iterators to compare against.
+     * @var \AppendIterator
+     */
+    private \AppendIterator $iterator_compare;
+
+    /**
+     * The value of {@see DiffIterator::accept()} when the values equal.
+     * @var bool
+     */
+    protected bool $equal_accept = false;
+
+    /**
+     * Whether the value should be compared including the key.
+     * @var bool
+     */
+    private bool $with_associative = false;
+
+    /**
+     * @inheritdoc
+     * @since $ver$
+     */
+    public function __construct(\Iterator $iterator, \Iterator ...$iterators)
+    {
+        parent::__construct($iterator);
+
+        $this->iterator_compare = new \AppendIterator();
+
+        foreach ($iterators as $iterator_compare) {
+            $this->iterator_compare->append($iterator_compare);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     * @since $ver$
+     */
+    public function accept(): bool
+    {
+        foreach ($this->iterator_compare as $key => $compare) {
+            if ($compare === $this->current()) {
+                if ($this->with_associative && $key !== $this->key()) {
+                    continue;
+                }
+
+                return $this->equal_accept;
+            }
+        }
+
+        return !$this->equal_accept;
+    }
+
+    /**
+     * Sets the iterator whether to compare with an extra key check.
+     * @param bool $bool Whether the iterator should be compared with extra key check.
+     * @return $this The iterator.
+     */
+    public function withAssociative(bool $bool): self
+    {
+        $this->with_associative = $bool;
+
+        return $this;
+    }
+}

--- a/src/Iterator/IntersectIterator.php
+++ b/src/Iterator/IntersectIterator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DoekeNorg\IteratorFunctions\Iterator;
+
+/**
+ * Iterator that computes the intersection between multiple iterators.
+ */
+class IntersectIterator extends DiffIterator
+{
+    /**
+     * @inheritdoc
+     */
+    protected bool $equal_accept = true;
+}

--- a/src/iterator_functions.php
+++ b/src/iterator_functions.php
@@ -1,7 +1,9 @@
 <?php
 
 use DoekeNorg\IteratorFunctions\Iterator\ColumnIterator;
+use DoekeNorg\IteratorFunctions\Iterator\DiffIterator;
 use DoekeNorg\IteratorFunctions\Iterator\FlipIterator;
+use DoekeNorg\IteratorFunctions\Iterator\IntersectIterator;
 use DoekeNorg\IteratorFunctions\Iterator\KeysIterator;
 use DoekeNorg\IteratorFunctions\Iterator\MapIterator;
 use DoekeNorg\IteratorFunctions\Iterator\ValuesIterator;
@@ -16,6 +18,32 @@ if (!function_exists('iterator_column')) {
     function iterator_column(\Traversable $iterator, $column_key, $index_key = null): ColumnIterator
     {
         return new ColumnIterator($iterator, $column_key, $index_key);
+    }
+}
+
+if (!function_exists('iterator_diff')) {
+    /**
+     * Computes the difference of iterators.
+     * @param \Iterator $iterator The iterator to compare from.
+     * @param \Iterator ...$iterators The iterators to compare against.
+     * @return DiffIterator An iterator with the difference.
+     */
+    function iterator_diff(\Iterator $iterator, \Iterator ...$iterators): DiffIterator
+    {
+        return new DiffIterator($iterator, ...$iterators);
+    }
+}
+
+if (!function_exists('iterator_diff_assoc')) {
+    /**
+     * Computes the difference of iterators with extra key check.
+     * @param \Iterator $iterator The iterator to compare from.
+     * @param \Iterator ...$iterators The iterators to compare against.
+     * @return DiffIterator An iterator with the difference.
+     */
+    function iterator_diff_assoc(\Iterator $iterator, \Iterator ...$iterators): DiffIterator
+    {
+        return (new DiffIterator($iterator, ...$iterators))->withAssociative(true);
     }
 }
 
@@ -44,6 +72,32 @@ if (!function_exists('iterator_flip')) {
     function iterator_flip(Iterator $iterator): FlipIterator
     {
         return new FlipIterator($iterator);
+    }
+}
+
+if (!function_exists('iterator_intersect')) {
+    /**
+     * Computes the difference between iterators.
+     * @param \Iterator $iterator The iterator to compare from.
+     * @param \Iterator ...$iterators The iterators to compare against.
+     * @return IntersectIterator An iterator with the intersection.
+     */
+    function iterator_intersect(\Iterator $iterator, \Iterator ...$iterators): IntersectIterator
+    {
+        return new IntersectIterator($iterator, ...$iterators);
+    }
+}
+
+if (!function_exists('iterator_intersect_assoc')) {
+    /**
+     * Computes the difference between iterators with extra key check.
+     * @param \Iterator $iterator The iterator to compare from.
+     * @param \Iterator ...$iterators The iterators to compare against.
+     * @return IntersectIterator An iterator with the intersection.
+     */
+    function iterator_intersect_assoc(\Iterator $iterator, \Iterator ...$iterators): IntersectIterator
+    {
+        return (new IntersectIterator($iterator, ...$iterators))->withAssociative(true);
     }
 }
 

--- a/tests/Functions/IteratorDiffAssocTest.php
+++ b/tests/Functions/IteratorDiffAssocTest.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Tests for {@see iterator_diff_assoc()}.
+ */
+it('diffs two iterators associatively', function () {
+    $iterator_1 = new ArrayIterator(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
+    $iterator_2 = new ArrayIterator(['a' => 'green', 'yellow', 'red']);
+
+    $result = iterator_diff_assoc($iterator_1, $iterator_2);
+
+    expect(iterator_to_array($result))->toBe(['b' => 'brown', 'c' => 'blue', 0 => 'red']);
+});

--- a/tests/Functions/IteratorDiffTest.php
+++ b/tests/Functions/IteratorDiffTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Tests for {@see iterator_diff()}.
+ */
+
+it('diffs two iterators', function () {
+    $iterator_1 = new ArrayIterator([1, 2, 3]);
+    $iterator_2 = new ArrayIterator([2, 3, 4]);
+
+    $iterator_diff = iterator_diff($iterator_1, $iterator_2);
+    $iterator_diff_2 = iterator_diff($iterator_2, $iterator_1);
+
+    expect(iterator_to_array($iterator_diff))->toBe([0 => 1]);
+    expect(iterator_to_array($iterator_diff_2))->toBe([2 => 4]);
+});
+
+it('diffs more than two iterators', function () {
+    $iterator_1 = new ArrayIterator([1, 2, 3, 'one', 'two', 'three']);
+    $iterator_2 = new ArrayIterator([2, 3, 4]);
+    $iterator_3 = new ArrayIterator(['three', 'four', 'five']);
+
+    $iterator_diff = iterator_diff($iterator_1, $iterator_2, $iterator_3);
+
+    expect(iterator_to_array($iterator_diff))->toBe([0 => 1, 3 => 'one', 4 => 'two']);
+});

--- a/tests/Functions/IteratorIntersectAssocTest.php
+++ b/tests/Functions/IteratorIntersectAssocTest.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Tests for {@see iterator_intersect_assoc()}.
+ */
+
+it('intersects two iterators associatively', function () {
+    $iterator_1 = new ArrayIterator(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
+    $iterator_2 = new ArrayIterator(['a' => 'green', 'yellow', 'red']);
+
+    $result = iterator_intersect_assoc($iterator_1, $iterator_2);
+
+    expect(iterator_to_array($result))->toBe(['a' => 'green']);
+});

--- a/tests/Functions/IteratorIntersectTest.php
+++ b/tests/Functions/IteratorIntersectTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Tests for {@see iterator_intersect()}.
+ */
+
+it('intersects two iterators', function () {
+    $iterator_1 = new ArrayIterator([1, 2, 3]);
+    $iterator_2 = new ArrayIterator([2, 3, 4]);
+
+    $iterator_intersect = iterator_intersect($iterator_1, $iterator_2);
+    $iterator_intersect_2 = iterator_intersect($iterator_2, $iterator_1);
+
+    expect(iterator_to_array($iterator_intersect))->toBe([1 => 2, 2 => 3]);
+    expect(iterator_to_array($iterator_intersect_2))->toBe([0 => 2, 1 => 3]);
+});
+
+it('intersects more than two iterators', function () {
+    $iterator_1 = new ArrayIterator([1, 2, 3, 'one', 'two', 'three']);
+    $iterator_2 = new ArrayIterator([2, 3, 4]);
+    $iterator_3 = new ArrayIterator(['three', 'four', 'five']);
+
+    $iterator_intersect = iterator_intersect($iterator_1, $iterator_2, $iterator_3);
+
+    expect(iterator_to_array($iterator_intersect))->toBe([1 => 2, 2 => 3, 5 => 'three']);
+});


### PR DESCRIPTION
Unlike stated in the `README` it can be possible to implement `_diff` and `_intersect` functions by repeatedly looping of the provided iterators. Because this is probably not the most performant check, for now this PR is mostly an experiment. It remains to be seen if it will be released.

This PR tries to implement the following functions: 

- [x] `iterator_diff`
- [x] `iterator_diff_assoc`
- [ ] `iterator_diff_key`
- [ ] `iterator_diff_uassoc`
- [ ] `iterator_diff_ukey`

- [ ] `iterator_udiff`
- [ ] `iterator_udiff_assoc`
- [ ] `iterator_udiff_uassoc`

- [x] `iterator_intersect`
- [x] `iterator_intersect_assoc`
- [ ] `iterator_intersect_key`
- [ ] `iterator_intersect_uassoc`
- [ ] `iterator_intersect_ukey`

- [ ] `iterator_uintersect`
- [ ] `iterator_uintersect_assoc`
- [ ] `iterator_uintersect_uassoc`
